### PR TITLE
Fix: Update listFilesInput getOptions params type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -64,7 +64,7 @@ export interface listFilesInput {
   apiKey: string,
   apiSecret: string,
   bucket?: string,
-  getOptions?: getOptionsListFiles,
+  getOptions?: getOptionsListFiles[],
 }
 
 export interface listFilesOutput {


### PR DESCRIPTION
**CHANGELOG**
- Type definition of `getOptions` in `listFilesInput` is updated to be an array