### PR TITLE
Add promise rejection on error to upload-file

### DIFF
--- a/utils/upload-file.js
+++ b/utils/upload-file.js
@@ -5,24 +5,28 @@ const uploadFile = (s3, params, cb = () => {}) => (new Promise((resolve, reject)
   const request = s3.putObject(params);
 
   request.on('complete', (response) => {
-    const { data: { ETag } } = response;
-
-    const hash = ETag.replace(/^"|"$/g, '');
-
-    const cidObj = CID.parse(hash);
-  
-    let cidv0;
-  
-    const cidv1 = cidObj.toV1().toString();
-
     try {
-      cidv0 = cidObj.toV0().toString();
-    } catch (e) {
-      // fallback when cbor is used
-      cidv0 = cidv1;
-    }
+      const { data: { ETag } } = response;
 
-    resolve ({ hash: cidv1, hashV0: cidv0 });
+      const hash = ETag.replace(/^"|"$/g, '');
+
+      const cidObj = CID.parse(hash);
+
+      let cidv0;
+
+      const cidv1 = cidObj.toV1().toString();
+
+      try {
+        cidv0 = cidObj.toV0().toString();
+      } catch (e) {
+        // fallback when cbor is used
+        cidv0 = cidv1;
+      }
+
+      resolve ({ hash: cidv1, hashV0: cidv0 });
+    } catch (e) {
+      reject(e);
+    }
   });
 
   request.on('error', (error) => {


### PR DESCRIPTION
The line 
```
const { data: { ETag } } = response;
```
can throw 
```
Error [TypeError]: Cannot read properties of null (reading 'ETag')
```
Because the error is thrown, but not rejected by the promise, it can't be handled by the caller. Wrapping the `complete` handler body in a `try { ... } catch (e) { reject(e); }` fixes this.