### PR TITLE
use "storageapi2.fleek.co" endpoint

### DIFF
--- a/__tests__/streamUpload.js
+++ b/__tests__/streamUpload.js
@@ -19,7 +19,7 @@ it('uploads a file', async () => {
     'hash': 'bafybeicaubxlzbr4sgc3tfwakfn7ganskxlgxmx25pdrcsojchgs3xpfqq',
     'hashV0': 'QmSgvgwxZGaBLqkGyWemEDqikCqU52XxsYLKtdy3vGZ8uq',
     'key': 'my-file',
-    'publicUrl': 'https://storageapi.fleek.co/bucket-1/my-file'
+    'publicUrl': 'https://storageapi2.fleek.co/bucket-1/my-file'
   };
 
   expect(file).toEqual(expectedResult);

--- a/__tests__/upload.js
+++ b/__tests__/upload.js
@@ -17,7 +17,7 @@ it('uploads a file', async () => {
     'hash': 'bafybeicaubxlzbr4sgc3tfwakfn7ganskxlgxmx25pdrcsojchgs3xpfqq',
     'hashV0': 'QmSgvgwxZGaBLqkGyWemEDqikCqU52XxsYLKtdy3vGZ8uq',
     'key': 'my-file',
-    'publicUrl': 'https://storageapi.fleek.co/bucket-1/my-file'
+    'publicUrl': 'https://storageapi2.fleek.co/bucket-1/my-file'
   };
 
   expect(file).toEqual(expectedResult);

--- a/config.js
+++ b/config.js
@@ -1,6 +1,6 @@
 const config = {
   ipfsGateway: 'https://ipfs.fleek.co/ipfs',
-  storageEndpoint: 'https://storageapi.fleek.co',
+  storageEndpoint: 'https://storageapi2.fleek.co',
   fleekGraphQl: 'https://h6qbvxquqjg5direndhm7ugaj4.appsync-api.us-west-2.amazonaws.com/graphql'
 };
 

--- a/utils/get-public-url.js
+++ b/utils/get-public-url.js
@@ -1,5 +1,5 @@
 const getPublicUrl = (bucket, filename) => (
-  `https://storageapi.fleek.co/${bucket}/${filename}`
+  `https://storageapi2.fleek.co/${bucket}/${filename}`
 );
 
 module.exports = getPublicUrl;


### PR DESCRIPTION
Description:

Fleek storage now uses the `storageapi2.fleek.co` endpoint, while the `fleek-storage-js` package still uses the `storageapi.fleek.co` endpoint. This causes problems with content availability on uploads. 


storage endpoints on Fleek UI:
![Screen Shot 2022-04-21 at 15 09 18](https://user-images.githubusercontent.com/955730/164561411-66dbe8b0-2e3a-487c-9753-6b72a1935890.png)


Scope of work:
- modified `config.js` & `get-public-url.js` to use `storageapi2.fleek.co`
- updated tests