### PR TITLE
feat: add contentType param on upload function

### DIFF
--- a/methods/upload.js
+++ b/methods/upload.js
@@ -9,6 +9,7 @@ const upload = async ({
   data,
   key,
   bucket,
+  contentType,
   httpUploadProgressCallback,
 }) => {
   try {
@@ -36,6 +37,7 @@ const upload = async ({
       Key: key,
       Body: data,
       ACL: 'public-read',
+      ContentType: contentType
     };
 
     const result = await uploadFile(s3, params, httpUploadProgressCallback);


### PR DESCRIPTION
AWS supports the contentType parameter, so the contentType parameter is added to the upload.