### PR TITLE
1.0.23 minor:  update storage URL

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,6 +1,6 @@
 const config = {
   ipfsGateway: 'https://ipfs.fleek.co/ipfs',
-  storageEndpoint: 'https://storageapi.fleek.co',
+  storageEndpoint: 'https://storageapi.fleek.one',
   fleekGraphQl: 'https://h6qbvxquqjg5direndhm7ugaj4.appsync-api.us-west-2.amazonaws.com/graphql'
 };
 

--- a/utils/init-s3.js
+++ b/utils/init-s3.js
@@ -1,7 +1,7 @@
 const AWS = require('aws-sdk');
 const { storageEndpoint } = require('../config');
 
-const initS3 = (apiKey, apiSecret) => {
+const initS3 = (apiKey, apiSecret, domain = '') => {
   if (!apiKey || !apiSecret) {
     throw new Error('Missing Fleek credentials.');
   }
@@ -10,7 +10,7 @@ const initS3 = (apiKey, apiSecret) => {
     apiVersion: '2006-03-01',
     accessKeyId: apiKey,
     secretAccessKey: apiSecret,
-    endpoint: storageEndpoint,
+    endpoint: domain ? domain : storageEndpoint,
     region: 'us-east-1',
     s3ForcePathStyle: true,
   });


### PR DESCRIPTION
- Updates storage url to new `storageapi.fleek.one`
- Adds domain as parameter supporting new custom storage domains, defaults to new storage URL